### PR TITLE
Gracefully handle case where empty field is slugified

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,19 @@ const { getSetupForData, getSetupForPage } = require("./lib/setup");
 
 module.exports.name = pkg.name;
 
-module.exports.transform = ({ data, log, options }) => {
+module.exports.transform = ({ data, debug, log, options }) => {
   if (typeof options.writeFile !== "function") {
     return data;
   }
 
   const utils = {
-    slugify
+    slugify: input => {
+      if (typeof input !== "string" || input.trim().length === 0) {
+        throw new Error("ERROR_FAILED_SLUGIFY");
+      }
+
+      return slugify(input);
+    }
   };
   const files = data.objects.reduce((result, object) => {
     let processedObject = object;
@@ -33,11 +39,33 @@ module.exports.transform = ({ data, log, options }) => {
       }, {});
     }
 
-    const writer = options.writeFile(processedObject, utils);
+    try {
+      const writer = options.writeFile(processedObject, utils);
 
-    if (!writer) return result;
+      if (!writer) return result;
 
-    return result.concat(writer);
+      return result.concat(writer);
+    } catch (error) {
+      const objectDetails =
+        object.__metadata && object.__metadata.id
+          ? ` (Object ID: ${object.__metadata.id})`
+          : "";
+
+      if (error.message === "ERROR_FAILED_SLUGIFY") {
+        log(
+          `Could not write object to disk because \`slugify()\` was used on an empty field.${objectDetails}`,
+          "fail"
+        );
+
+        debug(error);
+      } else {
+        log(`Could not write object to disk.${objectDetails} `, "fail");
+
+        debug(error);
+      }
+
+      return result;
+    }
   }, []);
 
   return {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports.transform = ({ data, debug, log, options }) => {
       return result.concat(writer);
     } catch (error) {
       const objectDetails =
-        object.__metadata && object.__metadata.id
+        object && object.__metadata && object.__metadata.id
           ? ` (Object ID: ${object.__metadata.id})`
           : "";
 


### PR DESCRIPTION
Currently, when `utils.slugify()` is used on an empty field, the operation fails with an error message that is not very clear. This PR changes that, so that the following is shown:

```
eduardoboucas@eduardo robust-avocado % sourcebit fetch
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkVT)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkZX)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkbZ)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkdb)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkfd)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkhf)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLkjh)
✖ Could not write object to disk because `slugify()` was used on an empty field. (Object ID: icb22HOpscEJNDFs0yLklj)
```